### PR TITLE
feat(diary): add configurable diary feature and keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@
 - **Smart Task Management** ✅  
   Toggle tasks with `<leader>wt` (`[ ]` ↔ `[x]`) and track nested task progress in real-time with dynamic updates.
 
-- **Robust Wiki Organization** 📂  
+- **Robust Wiki Organization** 📂
   Manage multiple wikis (e.g., work, personal) with automatic discovery of nested `index.md` files. Easily insert, rename, or delete wiki pages with automatic backlink updates.
+
+- **Diary Notes** 📅
+  Jump to today's entry, browse an index, or regenerate it with dedicated diary commands.
+  Daily files begin with a human-readable date header that you can configure via `diary.entry_header_format`.
 
 - **Neovim-Powered Efficiency** ⚙️  
   Built for Neovim 0.10+, leveraging Lua for speed and seamless integration with Treesitter, markdown rendering, completion, pickers, and your existing setup.
@@ -90,8 +94,9 @@ lua vim.keymap.set("n", "<leader>wT", require("neowiki").open_wiki_new_tab, { de
 1.  **Open Wiki**: Use `<leader>ww`, `<leader>wW`, or `<leader>wT` to start.
 2.  **Create Note**: Select text (e.g., “My Project”), press `<CR>` to create `[My Project](./My_Project.md)` and open it.
 3.  **Manage Tasks**: Use `<leader>wt` on a task line to toggle its status. Progress (e.g., `[ 75% ]`) will be displayed for parent items.
-4.  **Navigate**: Use `<Tab>`/`<S-Tab>` to jump between links, `<BS>` to return to the `index.md`, or `<leader>wr` to rename a page and update its links.
-5.  **Save**: Simply `:w`.
+4.  **Diary**: `<leader>w<leader>w` opens today's entry, `<leader>wi` jumps to the diary index, and `<leader>w<leader>i` regenerates it.
+5.  **Navigate**: Use `<Tab>`/`<S-Tab>` to jump between links, `<BS>` to return to the `index.md`, or `<leader>wr` to rename a page and update its links.
+6.  **Save**: Simply `:w`.
 
 ### Example Wiki Index
 ```markdown
@@ -134,8 +139,11 @@ The following keymaps are buffer-local and only active in markdown files within 
 | Visual | `<leader>wt`  | Toggle tasks         | Bulk create or toggle tasks in selection  |
 | Normal | `<leader>wd`  | Delete page          | Delete current or linked page             |
 | Normal | `<leader>wr`  | Rename page          | Rename current or linked page             |
-| Normal | `<leader>wi`  | Insert link          | Find and insert a link to a wiki page     |
+| Normal | `<leader>wl`  | Insert link          | Find and insert a link to a wiki page     |
 | Normal | `<leader>wc`  | Clean broken links   | Remove broken links from the current page |
+| Normal | `<leader>w<leader>w` | Open today's diary | Create or open today's diary note |
+| Normal | `<leader>wi`  | Diary index          | Open the diary index                      |
+| Normal | `<leader>w<leader>i` | Update diary index | Regenerate the diary index            |
 | Normal | `q`           | Close float          | Close the floating wiki window            |
 ## ⚙️ Default Configuration
 
@@ -159,6 +167,15 @@ require("neowiki").setup({
   -- Automatically discover and register nested wiki roots.
   discover_nested_roots = false,
 
+  -- Configuration for the diary functionality.
+  diary = {
+    rel_path = "diary",
+    index_file = "diary.md",
+    header = "Diary",
+    date_format = "%Y-%m-%d",
+    entry_header_format = "%a %b %d %Y",
+  },
+
   -- Defines the keymaps used by neowiki.
   -- Setting a keymap to `false` or an empty string will disable it.
   keymaps = {
@@ -178,14 +195,21 @@ require("neowiki").setup({
     -- Jumps to the index page of the current wiki.
     jump_to_index = "<Backspace>",
 
-    -- Renames the current wiki page and updates backlinks.
-    rename_page = "<leader>wr",
     -- Deletes the current wiki page and updates backlinks.
     delete_page = "<leader>wd",
-    -- Inserts a link to another wiki page.
-    insert_link = "<leader>wi",
     -- Removes all links in the current file that point to non-existent pages.
     cleanup_links = "<leader>wc",
+    -- Inserts a link to another wiki page.
+    insert_link = "<leader>wl",
+    -- Keymap to rename the current wiki page.
+    rename_page = "<leader>wr",
+
+    -- Opens today's diary entry.
+    open_diary_today = "<leader>w<leader>w",
+    -- Opens the diary index file.
+    open_diary_index = "<leader>wi",
+    -- Regenerates the diary index file.
+    update_diary_index = "<leader>w<leader>i",
 
     -- Toggles the status of a gtd item.
     -- Works on the current line in Normal mode and on the selection in Visual mode.
@@ -231,8 +255,17 @@ The following functions are exposed for use in custom mappings or scripts.
 -   `neowiki.open_wiki_new_tab({name})`  
     Same as `open_wiki()`, but opens in a new tab.
 
--   `neowiki.open_wiki_floating({name})`  
+-   `neowiki.open_wiki_floating({name})`
     Same as `open_wiki()`, but opens in a floating window.
+
+-   `neowiki.open_diary_today()`
+    Opens or creates today's diary note for the current wiki.
+
+-   `neowiki.open_diary_index()`
+    Opens the diary index file.
+
+-   `neowiki.update_diary_index()`
+    Regenerates the diary index by scanning diary entries.
 
 ### Custom Keymap Example
 ```lua
@@ -258,3 +291,4 @@ Big thanks to **kiwi.nvim** by [serenevoid](https://github.com/serenevoid/kiwi.n
 ## 📜 License
 
 [MIT License](./LICENSE)
+

--- a/doc/neowiki.txt
+++ b/doc/neowiki.txt
@@ -14,6 +14,7 @@ CONTENTS                                      *neowiki-contents*
 6. Configuration..............................|neowiki-configuration|
 7. Mappings...................................|neowiki-mappings|
 8. API........................................|neowiki-api|
+9. Diary......................................|neowiki-diary|
 ==============================================================================
 
 1. Introduction                               *neowiki-introduction*
@@ -49,8 +50,9 @@ Getting Things Done (GTD).
 - _Advanced Wiki Management_
   Rename or delete the current page—or the page under the cursor's link—with
   <leader>wr and <leader>wd, which automatically updates all backlinks.
-  Find and insert links with <leader>wi and clean up broken links with
-  <leader>wc.
+  Find and insert links with <leader>wl and clean up broken links with
+  <leader>wc. Open today's diary with <leader>w<leader>w and maintain an index
+  with <leader>wi and <leader>w<leader>i.
 
 - _Neovim Native_
   Harness Neovim 0.10+ with Lua speed, integrating seamlessly with
@@ -159,6 +161,15 @@ require("neowiki").setup({
   -- Automatically discover and register nested wiki roots.
   discover_nested_roots = false,
 
+  -- Configuration for the diary functionality.
+  diary = {
+    rel_path = "diary",
+    index_file = "diary.md",
+    header = "Diary",
+    date_format = "%Y-%m-%d",
+    entry_header_format = "%a %b %d %Y",
+  },
+
   -- Defines the keymaps used by neowiki.
   keymaps = {
     action_link = "<CR>",
@@ -173,8 +184,12 @@ require("neowiki").setup({
 
     delete_page = "<leader>wd",
     cleanup_links = "<leader>wc",
-    insert_link = "<leader>wi",
+    insert_link = "<leader>wl",
     rename_page = "<leader>wr",
+
+    open_diary_today = "<leader>w<leader>w",
+    open_diary_index = "<leader>wi",
+    update_diary_index = "<leader>w<leader>i",
 
     toggle_task = "<leader>wt",
 
@@ -234,8 +249,11 @@ directory.
 | Visual   | `<leader>wt`      | Toggle task status for selection    |
 | Normal   | `<leader>wd`      | Delete current or linked page       |
 | Normal   | `<leader>wc`      | Clean up broken links in file       |
-| Normal   | `<leader>wi`      | Find and insert a link to a page    |
+| Normal   | `<leader>wl`      | Find and insert a link to a page    |
 | Normal   | `<leader>wr`      | Rename current or linked page       |
+| Normal   | `<leader>w<leader>w` | Open today's diary entry        |
+| Normal   | `<leader>wi`      | Open the diary index                |
+| Normal   | `<leader>w<leader>i` | Regenerate the diary index       |
 | Normal   | `q`               | Close the floating window           |
 ==============================================================================
 
@@ -284,5 +302,49 @@ Usage:
 >lua
   vim.keymap.set('n', '<leader>wW', "<cmd>lua require('neowiki').open_wiki_floating()<cr>")
 <
+
+------------------------------------------------------------------------------
+*neowiki.open_diary_today()*
+
+Opens or creates today's diary entry for the current wiki.
+
+------------------------------------------------------------------------------
+*neowiki.open_diary_index()*
+
+Opens the diary index file for the current wiki.
+
+------------------------------------------------------------------------------
+*neowiki.update_diary_index()*
+
+Regenerates the diary index by scanning existing diary pages.
+
+==============================================================================
+
+9. Diary                                    *neowiki-diary*
+
+The diary feature provides quick access to daily notes and an index of past
+entries.
+
+New entries begin with a first-level header containing the current date. The
+format can be configured via `diary.entry_header_format`.
+
+Mappings:
+- `<leader>w<leader>w` — open or create today's diary entry
+- `<leader>wi` — open the diary index
+- `<leader>w<leader>i` — rebuild the diary index
+
+Configuration:
+>lua
+  diary = {
+    rel_path = "diary",
+    index_file = "diary.md",
+    header = "Diary",
+    date_format = "%Y-%m-%d",
+    entry_header_format = "%a %b %d %Y",
+  }
+<
+
+See also |neowiki.open_diary_today()|, |neowiki.open_diary_index()| and
+|neowiki.update_diary_index()|.
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/neowiki/api.lua
+++ b/lua/neowiki/api.lua
@@ -176,21 +176,21 @@ end
 -- Opens today's diary entry.
 --
 M.open_diary_today = function()
-  diary.open_diary_today()
+  diary.open_today()
 end
 
 ---
 -- Opens the diary index page.
 --
 M.open_diary_index = function()
-  diary.open_diary_index()
+  diary.open_index()
 end
 
 ---
 -- Updates the diary index.
 --
 M.update_diary_index = function()
-  diary.update_diary_index()
+  diary.update_index()
 end
 
 return M

--- a/lua/neowiki/config.lua
+++ b/lua/neowiki/config.lua
@@ -31,10 +31,12 @@ local config = {
     rel_path = "diary",
     -- Name of the diary index file.
     index_file = "diary.md",
-    -- Header inserted into newly created diary entries.
+    -- Header used for the diary index file.
     header = "Diary",
-    -- Date format used for diary entries.
+    -- Date format used for diary entry filenames.
     date_format = "%Y-%m-%d",
+    -- Format for the first line of new diary entries.
+    entry_header_format = "%a %b %d %Y",
   },
 
   -- Defines the keymaps used by neowiki.

--- a/lua/neowiki/features/diary.lua
+++ b/lua/neowiki/features/diary.lua
@@ -5,6 +5,7 @@ local state = require("neowiki.state")
 local actions = require("neowiki.core.actions")
 
 local M = {}
+local diary_cfg = config.diary
 
 ---
 -- Adds a new path to the navigation history.
@@ -45,6 +46,27 @@ local function open_file(full_path)
   end
 end
 
+local function fmt_to_pattern(fmt)
+  local order = {}
+  local pattern = fmt:gsub("%%[Ymd]", function(spec)
+    local c = spec:sub(2)
+    table.insert(order, c)
+    if c == "Y" then
+      return "(%d%d%d%d)"
+    else
+      return "(%d%d)"
+    end
+  end)
+  return "^" .. pattern .. "$", order
+end
+
+local function format_from_parts(fmt, year, month, day)
+  local rep = { Y = year, m = month, d = day }
+  return (fmt:gsub("%%([Ymd])", function(k)
+    return rep[k]
+  end))
+end
+
 ---
 -- Resolves and ensures the diary directory for the current wiki.
 -- @return string|nil The absolute path to the diary directory or nil if outside a wiki.
@@ -58,7 +80,7 @@ local function get_diary_dir()
   if not active_wiki_path then
     return nil
   end
-  local diary_dir = util.join_path(active_wiki_path, "diary")
+  local diary_dir = util.join_path(active_wiki_path, diary_cfg.rel_path)
   util.ensure_path_exists(diary_dir)
   return diary_dir
 end
@@ -74,13 +96,15 @@ M.open_today = function()
     return
   end
 
-  local today = os.date("%Y-%m-%d")
+  local today = os.date(diary_cfg.date_format)
   local ext = state.markdown_extension or ".md"
   local diary_path = util.join_path(diary_dir, today .. ext)
 
   if vim.fn.filereadable(diary_path) == 0 then
     local ok, err = pcall(function()
       local f = assert(io.open(diary_path, "w"), "Failed to create diary file.")
+      local header = os.date(diary_cfg.entry_header_format)
+      f:write("# " .. header .. "\n\n")
       f:close()
     end)
     if not ok then
@@ -102,10 +126,11 @@ M.open_index = function()
     return
   end
 
-  local index_path = util.join_path(diary_dir, config.index_file)
+  local index_path = util.join_path(diary_dir, diary_cfg.index_file)
   if vim.fn.filereadable(index_path) == 0 then
     local ok, err = pcall(function()
       local f = assert(io.open(index_path, "w"), "Failed to create diary index file.")
+      f:write("# " .. diary_cfg.header .. "\n\n")
       f:close()
     end)
     if not ok then
@@ -130,16 +155,25 @@ M.update_index = function()
 
   local ext = state.markdown_extension or ".md"
   local files = finder.find_wiki_pages(diary_dir, ext)
+  local pattern, order = fmt_to_pattern(diary_cfg.date_format)
 
   local entries = {}
   for _, file in ipairs(files or {}) do
     local fname = vim.fn.fnamemodify(file, ":t")
-    if fname ~= config.index_file then
-      local y, m, d = fname:match("^(%d%d%d%d)%-(%d%d)%-(%d%d)")
-      if y and m and d then
-        entries[y] = entries[y] or {}
-        entries[y][m] = entries[y][m] or {}
-        table.insert(entries[y][m], d)
+    if fname ~= diary_cfg.index_file then
+      local stem = vim.fn.fnamemodify(file, ":t:r")
+      local caps = { stem:match(pattern) }
+      if #caps == #order then
+        local parts = {}
+        for i, tok in ipairs(order) do
+          parts[tok] = caps[i]
+        end
+        local y, m, d = parts.Y, parts.m, parts.d
+        if y and m and d then
+          entries[y] = entries[y] or {}
+          entries[y][m] = entries[y][m] or {}
+          table.insert(entries[y][m], d)
+        end
       end
     end
   end
@@ -152,7 +186,7 @@ M.update_index = function()
     return a > b
   end)
 
-  local lines = { "# Diary Index", "" }
+  local lines = { "# " .. diary_cfg.header, "" }
   for _, year in ipairs(years) do
     table.insert(lines, "## " .. year)
     local months = {}
@@ -168,7 +202,7 @@ M.update_index = function()
         return a > b
       end)
       for _, day in ipairs(entries[year][month]) do
-        local date_str = string.format("%s-%s-%s", year, month, day)
+        local date_str = format_from_parts(diary_cfg.date_format, year, month, day)
         local link = string.format("[%s](./%s%s)", date_str, date_str, ext)
         table.insert(lines, "- " .. link)
       end
@@ -176,7 +210,7 @@ M.update_index = function()
     end
   end
 
-  local index_path = util.join_path(diary_dir, config.index_file)
+  local index_path = util.join_path(diary_dir, diary_cfg.index_file)
   local ok, err = pcall(function()
     local f = assert(io.open(index_path, "w"), "Failed to write diary index.")
     f:write(table.concat(lines, "\n"))
@@ -184,6 +218,14 @@ M.update_index = function()
   end)
   if not ok then
     vim.notify("Error writing diary index: " .. err, vim.log.levels.ERROR, { title = "neowiki" })
+    return
+  end
+
+  local bufnr = vim.fn.bufnr(index_path)
+  if bufnr > 0 and vim.api.nvim_buf_is_loaded(bufnr) then
+    vim.api.nvim_buf_call(bufnr, function()
+      vim.cmd("silent! edit!")
+    end)
   end
 end
 


### PR DESCRIPTION
## Summary
- allow configuring diary entry headers with `diary.entry_header_format`
- reload the diary index buffer after regenerating the index
- document diary entry header formatting in README and help

## Testing
- `stylua lua/neowiki/config.lua lua/neowiki/features/diary.lua`


------
https://chatgpt.com/codex/tasks/task_e_6890ce44411c832b84686e6e9e7f33d7