### PR TITLE
feat(diary): add optional auto-update index

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   Manage multiple wikis (e.g., work, personal) with automatic discovery of nested `index.md` files. Easily insert, rename, or delete wiki pages with automatic backlink updates.
 
 - **Diary Notes** 📅
-  Jump to today's entry, browse an index, or regenerate it with dedicated diary commands.
+  Jump to today's entry, browse an index, or regenerate it with dedicated diary commands. Optionally auto-update the diary index when creating new entries via `diary.auto_update_index`.
   
   Diary files live in a sibling `diary/` directory alongside your wiki (e.g. `personal/wiki` and `personal/diary`).
   
@@ -178,6 +178,8 @@ require("neowiki").setup({
     header = "Diary",
     date_format = "%Y-%m-%d",
     entry_header_format = "%a %b %d %Y",
+    -- Automatically update the diary index after creating a new entry.
+    auto_update_index = false,
   },
 
   -- Defines the keymaps used by neowiki.

--- a/lua/neowiki/config.lua
+++ b/lua/neowiki/config.lua
@@ -37,6 +37,8 @@ local config = {
     date_format = "%Y-%m-%d",
     -- Format for the first line of new diary entries.
     entry_header_format = "%a %b %d %Y",
+    -- Automatically update the diary index after creating a new entry.
+    auto_update_index = false,
   },
 
   -- Defines the keymaps used by neowiki.

--- a/lua/neowiki/features/diary.lua
+++ b/lua/neowiki/features/diary.lua
@@ -76,7 +76,7 @@ M.open_today = function()
   local today = os.date(diary_cfg.date_format)
   local ext = state.markdown_extension or ".md"
   local diary_path = util.join_path(diary_dir, today .. ext)
-
+  local created = false
   if vim.fn.filereadable(diary_path) == 0 then
     local ok, err = pcall(function()
       local f = assert(io.open(diary_path, "w"), "Failed to create diary file.")
@@ -88,6 +88,11 @@ M.open_today = function()
       vim.notify("Error creating diary file: " .. err, vim.log.levels.ERROR, { title = "neowiki" })
       return
     end
+    created = true
+  end
+
+  if created and diary_cfg.auto_update_index then
+    M.update_index()
   end
 
   navigation.add_to_history(diary_path)


### PR DESCRIPTION
## Summary
- add `diary.auto_update_index` config flag
- auto-update diary index when creating today's entry if enabled
- document auto-update diary option

## Testing
- `stylua lua/neowiki/config.lua lua/neowiki/features/diary.lua`
- `luacheck lua/neowiki/config.lua lua/neowiki/features/diary.lua` *(fails: accessing undefined variable vim, mutating non-standard global variable vim)*

------
https://chatgpt.com/codex/tasks/task_e_68912d458b8c832bb51d63e05a2a3b72