### PR TITLE
feat(diary): add entry template for new entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   
   Diary files live in a sibling `diary/` directory alongside your wiki (e.g. `personal/wiki` and `personal/diary`).
   
-  Daily files begin with a human-readable date header that you can configure via `diary.entry_header_format`.
+  Daily files are seeded from a template via `diary.entry_template`. String templates are processed by `os.date` so you can embed the current date. If unset, a simple header using `diary.entry_header_format` is inserted.
 
 - **Neovim-Powered Efficiency** ⚙️  
   Built for Neovim 0.10+, leveraging Lua for speed and seamless integration with Treesitter, markdown rendering, completion, pickers, and your existing setup.
@@ -177,7 +177,9 @@ require("neowiki").setup({
     index_file = "diary.md",
     header = "Diary",
     date_format = "%Y-%m-%d",
-    entry_header_format = "%a %b %d %Y",
+    entry_header_format = "%a %b %d %Y", -- used when entry_template is nil
+    -- Optional template for new entries. Strings use os.date() for placeholders.
+    entry_template = nil,
     -- Automatically update the diary index after creating a new entry.
     auto_update_index = false,
   },

--- a/lua/neowiki/config.lua
+++ b/lua/neowiki/config.lua
@@ -35,8 +35,12 @@ local config = {
     header = "Diary",
     -- Date format used for diary entry filenames.
     date_format = "%Y-%m-%d",
-    -- Format for the first line of new diary entries.
+    -- Format for the first line of new diary entries when no template is provided.
     entry_header_format = "%a %b %d %Y",
+    -- Template for new diary entries. Strings are processed with os.date().
+    -- Can also be a function returning a string.
+    -- Defaults to a header based on entry_header_format.
+    entry_template = nil,
     -- Automatically update the diary index after creating a new entry.
     auto_update_index = false,
   },

--- a/lua/neowiki/features/diary.lua
+++ b/lua/neowiki/features/diary.lua
@@ -81,8 +81,16 @@ M.open_today = function()
   if vim.fn.filereadable(diary_path) == 0 then
     local ok, err = pcall(function()
       local f = assert(io.open(diary_path, "w"), "Failed to create diary file.")
-      local header = os.date(diary_cfg.entry_header_format)
-      f:write("# " .. header .. "\n\n")
+      local content
+      if type(diary_cfg.entry_template) == "function" then
+        content = diary_cfg.entry_template()
+      elseif type(diary_cfg.entry_template) == "string" then
+        content = os.date(diary_cfg.entry_template)
+      else
+        local header = os.date(diary_cfg.entry_header_format)
+        content = "# " .. header .. "\n\n"
+      end
+      f:write(content)
       f:close()
     end)
     if not ok then


### PR DESCRIPTION
## Summary
- allow configuring `diary.entry_template` as string or function
- use template when creating today's diary entry
- document diary templates

## Testing
- `stylua lua/neowiki/config.lua lua/neowiki/features/diary.lua`


------
https://chatgpt.com/codex/tasks/task_e_6894d97e385c832b99744eb089f267cc