### PR TITLE
feat: make diary entry directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 - **Diary Notes** 📅
   Jump to today's entry, browse an index, or regenerate it with dedicated diary commands. Optionally auto-update the diary index when creating new entries via `diary.auto_update_index`.
   
-  Diary files live in a sibling `diary/` directory alongside your wiki (e.g. `personal/wiki` and `personal/diary`).
+  Diary files live in a sibling `diary/` directory alongside your wiki (e.g. `personal/wiki` and `personal/diary`). Entries may
+  be placed in a subdirectory like `diary/posts` using `diary.entries_rel_path`.
   
   Daily files are seeded from a template via `diary.entry_template`. String templates are processed by `os.date` so you can embed the current date. If unset, a simple header using `diary.entry_header_format` is inserted.
 
@@ -172,8 +173,11 @@ require("neowiki").setup({
 
   -- Configuration for the diary functionality.
   diary = {
-    -- Subdirectory (relative to the wiki's parent directory) where diary entries are stored.
+    -- Subdirectory (relative to the wiki's parent directory) where diary files are stored.
     rel_path = "diary",
+    -- Optional subdirectory within `rel_path` for diary entries.
+    -- If nil or empty, entries are kept directly in `rel_path`.
+    entries_rel_path = nil,
     index_file = "diary.md",
     header = "Diary",
     date_format = "%Y-%m-%d",

--- a/doc/neowiki.txt
+++ b/doc/neowiki.txt
@@ -163,8 +163,11 @@ require("neowiki").setup({
 
   -- Configuration for the diary functionality.
   diary = {
-    -- Subdirectory (relative to the wiki's parent directory) where diary entries are stored.
+    -- Subdirectory (relative to the wiki's parent directory) where diary files are stored.
     rel_path = "diary",
+    -- Optional subdirectory within `rel_path` where diary entries live.
+    -- If nil or empty, entries are stored directly in `rel_path`.
+    entries_rel_path = nil,
     index_file = "diary.md",
     header = "Diary",
     date_format = "%Y-%m-%d",
@@ -325,7 +328,8 @@ Regenerates the diary index by scanning existing diary pages.
 
 The diary feature provides quick access to daily notes and an index of past
 entries. Diary files reside in a sibling `diary/` directory next to your wiki
-content (e.g. `personal/wiki` and `personal/diary`).
+content (e.g. `personal/wiki` and `personal/diary`). Entries can optionally
+be placed in a subdirectory (e.g. `diary/posts`) via `diary.entries_rel_path`.
 
 New entries begin with a first-level header containing the current date. The
 format can be configured via `diary.entry_header_format`.
@@ -338,8 +342,11 @@ Mappings:
 Configuration:
 >lua
   diary = {
-    -- Subdirectory (relative to the wiki's parent directory) where diary entries are stored.
+    -- Subdirectory (relative to the wiki's parent directory) where diary files are stored.
     rel_path = "diary",
+    -- Optional subdirectory within `rel_path` where diary entries live.
+    -- If nil or empty, entries are stored directly in `rel_path`.
+    entries_rel_path = nil,
     index_file = "diary.md",
     header = "Diary",
     date_format = "%Y-%m-%d",

--- a/lua/neowiki/config.lua
+++ b/lua/neowiki/config.lua
@@ -27,8 +27,11 @@ local config = {
 
   -- Configuration for the diary functionality.
   diary = {
-    -- Subdirectory (relative to the wiki's parent directory) where diary entries are stored.
+    -- Subdirectory (relative to the wiki's parent directory) where diary files are stored.
     rel_path = "diary",
+    -- Optional subdirectory within `rel_path` where diary entries are stored.
+    -- If nil or empty, entries are kept directly in `rel_path`.
+    entries_rel_path = nil,
     -- Name of the diary index file.
     index_file = "diary.md",
     -- Header used for the diary index file.

--- a/lua/neowiki/features/diary.lua
+++ b/lua/neowiki/features/diary.lua
@@ -67,8 +67,9 @@ end
 
 ---
 -- Resolves and ensures the diary directory for the current wiki.
--- @return string|nil, string|nil, string|nil, string|nil
---   - The absolute path to the diary directory or nil if outside a wiki.
+-- @return string|nil, string|nil, string|nil, string|nil, string|nil
+--   - The absolute path to the diary root directory or nil if outside a wiki.
+--   - The absolute path to the directory containing diary entries.
 --   - The wiki_root of the calling buffer.
 --   - The active_wiki_path of the calling buffer.
 --   - The ultimate_wiki_root of the calling buffer.
@@ -87,7 +88,12 @@ local function get_diary_dir()
   local parent = vim.fn.fnamemodify(wiki_root, ":h")
   local diary_dir = util.join_path(parent, diary_cfg.rel_path)
   util.ensure_path_exists(diary_dir)
-  return diary_dir, wiki_root, active_wiki_path, ultimate_wiki_root
+  local entries_dir = diary_cfg.entries_rel_path
+      and diary_cfg.entries_rel_path ~= ""
+      and util.join_path(diary_dir, diary_cfg.entries_rel_path)
+    or diary_dir
+  util.ensure_path_exists(entries_dir)
+  return diary_dir, entries_dir, wiki_root, active_wiki_path, ultimate_wiki_root
 end
 
 ---
@@ -96,14 +102,14 @@ end
 -- then opens it and records it in the navigation history.
 --
 M.open_today = function()
-  local diary_dir, wiki_root, active_wiki_path, ultimate_wiki_root = get_diary_dir()
+  local diary_dir, entries_dir, wiki_root, active_wiki_path, ultimate_wiki_root = get_diary_dir()
   if not diary_dir then
     return
   end
 
   local today = os.date(diary_cfg.date_format)
   local ext = state.markdown_extension or ".md"
-  local diary_path = util.join_path(diary_dir, today .. ext)
+  local diary_path = util.join_path(entries_dir, today .. ext)
   local created = false
   if vim.fn.filereadable(diary_path) == 0 then
     local ok, err = pcall(function()
@@ -142,7 +148,7 @@ end
 -- Opens or creates the diary index file.
 --
 M.open_index = function()
-  local diary_dir, wiki_root, active_wiki_path, ultimate_wiki_root = get_diary_dir()
+  local diary_dir, _, wiki_root, active_wiki_path, ultimate_wiki_root = get_diary_dir()
   if not diary_dir then
     return
   end
@@ -220,7 +226,7 @@ end
 -- File discovery and parsing are run in a background job.
 --
 M.update_index = function()
-  local diary_dir = get_diary_dir()
+  local diary_dir, entries_dir = get_diary_dir()
   if not diary_dir then
     return
   end
@@ -241,7 +247,7 @@ M.update_index = function()
     "-c",
     string.format(
       "lua require('neowiki.features.diary')._collect_entries(%q, %q, %q)",
-      diary_dir,
+      entries_dir,
       ext,
       diary_cfg.date_format
     ),
@@ -322,7 +328,11 @@ M.update_index = function()
             for _, day_num in ipairs(days) do
               local day = string.format("%02d", day_num)
               local date_str = format_from_parts(diary_cfg.date_format, year, month, day)
-              local link = string.format("[%s](./%s%s)", date_str, date_str, ext)
+              local prefix = diary_cfg.entries_rel_path
+                  and diary_cfg.entries_rel_path ~= ""
+                  and (diary_cfg.entries_rel_path:gsub("/$", "") .. "/")
+                or ""
+              local link = string.format("[%s](./%s%s%s)", date_str, prefix, date_str, ext)
               table.insert(lines, "- " .. link)
             end
             table.insert(lines, "")


### PR DESCRIPTION
## Summary
- allow diary entries to live in a separate subdirectory via new `diary.entries_rel_path`
- update diary creation and index generation to respect `entries_rel_path`
- document the new option in README and help file

## Testing
- `stylua lua/neowiki/config.lua lua/neowiki/features/diary.lua`
- `luacheck lua/neowiki/features/diary.lua lua/neowiki/config.lua` *(reports 39 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689521d230f4832b8b51eeff33b9bcad