### PR TITLE
feat(diary): support template file for entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ require("neowiki").setup({
     -- Optional subdirectory within `rel_path` for diary entries.
     -- If nil or empty, entries are kept directly in `rel_path`.
     entries_rel_path = nil,
+    -- Directory (relative to the wiki root's parent) containing template files.
+    template_dir = nil,
+    -- Template filename for new diary entries located inside `template_dir`.
+    entry_template_file = nil,
     index_file = "diary.md",
     header = "Diary",
     date_format = "%Y-%m-%d",

--- a/doc/neowiki.txt
+++ b/doc/neowiki.txt
@@ -347,10 +347,18 @@ Configuration:
     -- Optional subdirectory within `rel_path` where diary entries live.
     -- If nil or empty, entries are stored directly in `rel_path`.
     entries_rel_path = nil,
+    -- Directory (relative to the wiki root's parent) containing template files.
+    template_dir = nil,
+    -- Template filename for new diary entries located inside `template_dir`.
+    entry_template_file = nil,
     index_file = "diary.md",
     header = "Diary",
     date_format = "%Y-%m-%d",
     entry_header_format = "%a %b %d %Y",
+    -- Optional template for new entries. Strings use os.date() for placeholders.
+    entry_template = nil,
+    -- Automatically update the diary index after creating a new entry.
+    auto_update_index = false,
   }
 <
 

--- a/lua/neowiki/config.lua
+++ b/lua/neowiki/config.lua
@@ -32,6 +32,10 @@ local config = {
     -- Optional subdirectory within `rel_path` where diary entries are stored.
     -- If nil or empty, entries are kept directly in `rel_path`.
     entries_rel_path = nil,
+    -- Directory (relative to the wiki root's parent) containing template files.
+    template_dir = nil,
+    -- Template filename for new diary entries located inside `template_dir`.
+    entry_template_file = nil,
     -- Name of the diary index file.
     index_file = "diary.md",
     -- Header used for the diary index file.

--- a/lua/neowiki/features/diary.lua
+++ b/lua/neowiki/features/diary.lua
@@ -107,6 +107,11 @@ M.open_today = function()
     return
   end
   local diary_cfg = config.diary
+  local parent = vim.fn.fnamemodify(wiki_root, ":h")
+  local template_path
+  if diary_cfg.template_dir and diary_cfg.entry_template_file then
+    template_path = util.join_path(parent, diary_cfg.template_dir, diary_cfg.entry_template_file)
+  end
   local today = os.date(diary_cfg.date_format)
   local ext = state.markdown_extension or ".md"
   local diary_path = util.join_path(entries_dir, today .. ext)
@@ -115,7 +120,12 @@ M.open_today = function()
     local ok, err = pcall(function()
       local f = assert(io.open(diary_path, "w"), "Failed to create diary file.")
       local content
-      if type(diary_cfg.entry_template) == "function" then
+      if template_path and vim.fn.filereadable(template_path) == 1 then
+        local tf = assert(io.open(template_path, "r"), "Failed to read diary template file.")
+        local tmpl = tf:read("*a")
+        tf:close()
+        content = os.date(tmpl)
+      elseif type(diary_cfg.entry_template) == "function" then
         content = diary_cfg.entry_template()
       elseif type(diary_cfg.entry_template) == "string" then
         content = os.date(diary_cfg.entry_template)


### PR DESCRIPTION
## Summary
- allow diary entry creation from a template file if present
- document new `template_dir` and `entry_template_file` options

## Testing
- `stylua lua/neowiki/features/diary.lua lua/neowiki/config.lua`
- `luacheck lua/neowiki/features/diary.lua lua/neowiki/config.lua` *(fails: many warnings about global vim)*

------
https://chatgpt.com/codex/tasks/task_e_6896190d6288832b9093c819964877f4