### PR TITLE
docs: document directory and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@
 - **Diary Notes** 📅
   Jump to today's entry, browse an index, or regenerate it with dedicated diary commands. Optionally auto-update the diary index when creating new entries via `diary.auto_update_index`.
   
-  Diary files live in a sibling `diary/` directory alongside your wiki (e.g. `personal/wiki` and `personal/diary`). Entries may
-  be placed in a subdirectory like `diary/posts` using `diary.entries_rel_path`.
-  
-  Daily files are seeded from a template via `diary.entry_template`. String templates are processed by `os.date` so you can embed the current date. If unset, a simple header using `diary.entry_header_format` is inserted.
+  Diary files live in a `diary/` directory within the wiki root. Entries may be placed in a subdirectory like `diary/posts`
+  using `diary.entries_rel_path`.
+
+  Daily files are seeded from a template via `diary.entry_template` or `diary.entry_template_file` inside a sibling
+  `templates/` directory. Both string templates and template files are processed by `os.date`, so placeholders like `%Y` or `%m`
+  are replaced with the current date. If unset, a simple header using `diary.entry_header_format` is inserted.
 
 - **Neovim-Powered Efficiency** ⚙️  
   Built for Neovim 0.10+, leveraging Lua for speed and seamless integration with Treesitter, markdown rendering, completion, pickers, and your existing setup.
@@ -55,7 +57,7 @@ Requires **Neovim >= 0.10**. For the best experience, install Treesitter’s `ma
     wiki_dirs = {
       -- neowiki.nvim supports both absolute and tilde-expanded paths
       { name = "Work", path = "~/work/wiki" },
-      { name = "Personal", path = "personal/wiki" },
+      { name = "Personal", path = "~/personal/wiki" },
     },
   },
   keys = {
@@ -83,6 +85,41 @@ lua vim.keymap.set("n", "<leader>ww", require("neowiki").open_wiki, { desc = "Op
 lua vim.keymap.set("n", "<leader>wW", require("neowiki").open_wiki_floating, { desc = "Open Floating Wiki" })
 lua vim.keymap.set("n", "<leader>wT", require("neowiki").open_wiki_new_tab, { desc = "Open Wiki in Tab" })
 ```
+
+## 📁 Directory Layout
+
+Each wiki root expects a simple structure:
+
+```
+wiki/
+├── index.md     # Markdown notes and wiki index
+├── diary/       # Daily entries (optional)
+└── templates/   # Reusable snippets for new pages
+```
+
+Configure the directories with `template_dir` and `diary.entry_template_file`:
+
+```lua
+require("neowiki").setup({
+  wiki_dirs = {
+    { name = "Personal", path = "~/wiki" },
+  },
+  template_dir = "templates", -- inside the wiki root
+  diary = {
+    entry_template_file = "diary.md", -- relative to template_dir
+  },
+})
+```
+
+Placeholders in template strings or files follow `os.date`'s `%`-style format. For example, a `templates/diary.md` like:
+
+```
+# %Y-%m-%d
+Agenda for %A
+```
+
+will expand to a dated header and weekday name when creating a new entry. Advanced templating engines (e.g. Jinja2) are not
+included and would require extra setup if adopted later.
 
 ## 🚀 Optional Dependencies
 
@@ -160,13 +197,17 @@ require("neowiki").setup({
   -- If this is nil, the plugin defaults to `~/wiki`.
   -- Example:
   -- wiki_dirs = {
-  --   { name = "Work", path = "~/Documents/work-wiki" },
-  --   { name = "Personal", path = "personal-wiki" },
+  --   { name = "Work", path = "~/Documents/work/wiki" },
+  --   { name = "Personal", path = "~/personal/wiki" },
   -- }
   wiki_dirs = nil,
 
   -- The filename for a wiki's index page (e.g., "index.md").
   index_file = "index.md",
+
+  -- Directory (relative to the wiki's parent directory) containing template files.
+  -- Used with `diary.entry_template_file`.
+  template_dir = "templates",
 
   -- Automatically discover and register nested wiki roots.
   discover_nested_roots = false,
@@ -184,6 +225,8 @@ require("neowiki").setup({
     entry_header_format = "%a %b %d %Y", -- used when entry_template is nil
     -- Optional template for new entries. Strings use os.date() for placeholders.
     entry_template = nil,
+    -- Alternatively, load the template from a file in `template_dir`.
+    entry_template_file = nil,
     -- Automatically update the diary index after creating a new entry.
     auto_update_index = false,
   },


### PR DESCRIPTION
## Summary
- clarify that `diary/` and `templates/` live inside the wiki root
- drop test-specific `docs/` paths in examples and directory layout
- show updated config for `template_dir` and `diary.entry_template_file`

## Testing
- `stylua --check lua`


------
https://chatgpt.com/codex/tasks/task_e_6896190df0bc832ba0b0be0537543879